### PR TITLE
Disable vimtex lazy loading.

### DIFF
--- a/nvim/.config/nvim/lua/core/plugins/vimtex.lua
+++ b/nvim/.config/nvim/lua/core/plugins/vimtex.lua
@@ -1,7 +1,6 @@
 return {
 	"lervag/vimtex",
-	ft = { "tex", "plaintex", "bib" },
-	-- lazy = false, -- lazy-loading will disable inverse search
+	lazy = false,
 	config = function()
 		vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
 		vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"


### PR DESCRIPTION
When you set ```lazy = false```, that disables lazy loading. When you set ```ft``` to something, that enables lazy loading, and vimtex only loads for those filetypes.

Vimtex is known to known to not behave well with lazyloading, snippets stop working if you do that.