### PR TITLE
Optimize options.lua

### DIFF
--- a/nvim/.config/nvim/lua/core/config/options.lua
+++ b/nvim/.config/nvim/lua/core/config/options.lua
@@ -3,7 +3,9 @@ vim.g.maplocalleader = "//"
 vim.g.autoformat = true
 vim.g.markdown_recommended_style = 0
 
+vim.opt.autochdir = true
 vim.opt.autoindent = true
+vim.opt.autoread = true
 vim.opt.autowrite = true
 vim.opt.backspace = "indent,eol,start"
 vim.opt.breakindent = true
@@ -42,6 +44,7 @@ vim.opt.spelllang = { "en" }
 vim.opt.splitbelow = true
 vim.opt.splitkeep = "screen"
 vim.opt.splitright = true
+vim.opt.swapfile = false
 vim.opt.tabstop = 4
 vim.opt.termguicolors = true
 vim.opt.timeoutlen = 300


### PR DESCRIPTION
1. autochdir: Neovim has a confusing cwd thing going on, cwd is where you open neovim from, and after that, if you open any other file from inside, cwd won't change automatically. This creates confusion. autochdir changes cwd automatically.
2. autoread: If a file changes outside of neovim, this option makes neovim automatically detect that change and update current buffer.
3. swapfile: When you are editing a file and have not saved, this option creates a temporary file in case power goes out and stuff like that, and if you quit without saving a file, and when you try to open it, it will ask if you want to restore it. But it is annoying and makes your system slow if you are editing a large file. And it is unrealistic that you make a large change and never save.